### PR TITLE
setup terrain movement prototype

### DIFF
--- a/Team Rhythm Project 1/Assets/Materials/terrain-1.mat
+++ b/Team Rhythm Project 1/Assets/Materials/terrain-1.mat
@@ -1,0 +1,68 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!21 &2100000
+Material:
+  serializedVersion: 6
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: terrain-1
+  m_Shader: {fileID: 4800000, guid: 933532a4fcc9baf4fa0491de14d08ed7, type: 3}
+  m_ShaderKeywords: 
+  m_LightmapFlags: 4
+  m_EnableInstancingVariants: 0
+  m_DoubleSidedGI: 0
+  m_CustomRenderQueue: -1
+  stringTagMap: {}
+  disabledShaderPasses: []
+  m_SavedProperties:
+    serializedVersion: 3
+    m_TexEnvs:
+    - _BumpMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _EmissionMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _MainTex:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _MetallicGlossMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _OcclusionMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _SpecGlossMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    m_Floats:
+    - _AlphaClip: 0
+    - _Blend: 0
+    - _BumpScale: 1
+    - _Cull: 2
+    - _Cutoff: 0.5
+    - _DstBlend: 0
+    - _GlossMapScale: 1
+    - _Glossiness: 0.5
+    - _GlossyReflections: 1
+    - _Metallic: 0
+    - _OcclusionStrength: 1
+    - _ReceiveShadows: 1
+    - _SmoothnessTextureChannel: 0
+    - _SpecularHighlights: 1
+    - _SrcBlend: 1
+    - _Surface: 0
+    - _WorkflowMode: 1
+    - _ZWrite: 1
+    m_Colors:
+    - _Color: {r: 0.29102886, g: 0.34229928, b: 0.5660378, a: 1}
+    - _EmissionColor: {r: 0, g: 0, b: 0, a: 1}
+    - _SpecColor: {r: 0.19999996, g: 0.19999996, b: 0.19999996, a: 1}

--- a/Team Rhythm Project 1/Assets/Materials/terrain-1.mat.meta
+++ b/Team Rhythm Project 1/Assets/Materials/terrain-1.mat.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 39a33aa0f8a39794595b7a207e62cad2
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 2100000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Team Rhythm Project 1/Assets/Materials/terrain-2.mat
+++ b/Team Rhythm Project 1/Assets/Materials/terrain-2.mat
@@ -7,7 +7,7 @@ Material:
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_Name: floor-plane-1
+  m_Name: terrain-2
   m_Shader: {fileID: 4800000, guid: 933532a4fcc9baf4fa0491de14d08ed7, type: 3}
   m_ShaderKeywords: 
   m_LightmapFlags: 4
@@ -51,7 +51,7 @@ Material:
     - _Cutoff: 0.5
     - _DstBlend: 0
     - _GlossMapScale: 1
-    - _Glossiness: 0
+    - _Glossiness: 0.5
     - _GlossyReflections: 1
     - _Metallic: 0
     - _OcclusionStrength: 1
@@ -63,6 +63,6 @@ Material:
     - _WorkflowMode: 1
     - _ZWrite: 1
     m_Colors:
-    - _Color: {r: 0.20754719, g: 0.16740835, b: 0.16740835, a: 1}
-    - _EmissionColor: {r: 0.1509434, g: 0.07244761, b: 0, a: 1}
+    - _Color: {r: 0.3113609, g: 0.8113208, b: 0.14159843, a: 1}
+    - _EmissionColor: {r: 0, g: 0, b: 0, a: 1}
     - _SpecColor: {r: 0.19999996, g: 0.19999996, b: 0.19999996, a: 1}

--- a/Team Rhythm Project 1/Assets/Materials/terrain-2.mat.meta
+++ b/Team Rhythm Project 1/Assets/Materials/terrain-2.mat.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: cfdd7e38ce44b93448c3f2079a5f88ce
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 2100000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Team Rhythm Project 1/Assets/Prefabs/Terrain_3D.prefab
+++ b/Team Rhythm Project 1/Assets/Prefabs/Terrain_3D.prefab
@@ -1,6 +1,6 @@
 %YAML 1.1
 %TAG !u! tag:unity3d.com,2011:
---- !u!1 &6227478506255462448
+--- !u!1 &2391261972711336665
 GameObject:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -8,46 +8,47 @@ GameObject:
   m_PrefabAsset: {fileID: 0}
   serializedVersion: 6
   m_Component:
-  - component: {fileID: 1727948863532124052}
-  - component: {fileID: 3284091602950715227}
-  - component: {fileID: 8881239349115591481}
-  - component: {fileID: 3430427759890004952}
+  - component: {fileID: 8337871931919476153}
+  - component: {fileID: 5077775050558789300}
+  - component: {fileID: 1874107682854845078}
+  - component: {fileID: 7666862222689239324}
+  - component: {fileID: 1625908925408136131}
   m_Layer: 0
-  m_Name: Plane
-  m_TagString: Untagged
+  m_Name: Terrain_3D
+  m_TagString: Terrain
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
---- !u!4 &1727948863532124052
+--- !u!4 &8337871931919476153
 Transform:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 6227478506255462448}
+  m_GameObject: {fileID: 2391261972711336665}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_LocalScale: {x: 10, y: 0.1, z: 10}
   m_Children: []
   m_Father: {fileID: 0}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!33 &3284091602950715227
+--- !u!33 &5077775050558789300
 MeshFilter:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 6227478506255462448}
-  m_Mesh: {fileID: 10209, guid: 0000000000000000e000000000000000, type: 0}
---- !u!23 &8881239349115591481
+  m_GameObject: {fileID: 2391261972711336665}
+  m_Mesh: {fileID: 10202, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!23 &1874107682854845078
 MeshRenderer:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 6227478506255462448}
+  m_GameObject: {fileID: 2391261972711336665}
   m_Enabled: 1
   m_CastShadows: 1
   m_ReceiveShadows: 1
@@ -58,7 +59,7 @@ MeshRenderer:
   m_RenderingLayerMask: 1
   m_RendererPriority: 0
   m_Materials:
-  - {fileID: 2100000, guid: 39a33aa0f8a39794595b7a207e62cad2, type: 2}
+  - {fileID: 2100000, guid: cfdd7e38ce44b93448c3f2079a5f88ce, type: 2}
   m_StaticBatchInfo:
     firstSubMesh: 0
     subMeshCount: 0
@@ -78,17 +79,29 @@ MeshRenderer:
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
---- !u!64 &3430427759890004952
-MeshCollider:
+--- !u!65 &7666862222689239324
+BoxCollider:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 6227478506255462448}
+  m_GameObject: {fileID: 2391261972711336665}
   m_Material: {fileID: 0}
   m_IsTrigger: 0
   m_Enabled: 1
-  serializedVersion: 3
-  m_Convex: 0
-  m_CookingOptions: 14
-  m_Mesh: {fileID: 10209, guid: 0000000000000000e000000000000000, type: 0}
+  serializedVersion: 2
+  m_Size: {x: 1, y: 1, z: 1}
+  m_Center: {x: 0, y: 0, z: 0}
+--- !u!114 &1625908925408136131
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2391261972711336665}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: ca896d818b73c3943a4e383b49550ae5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  terrainMovementSpeed: 0

--- a/Team Rhythm Project 1/Assets/Prefabs/Terrain_3D.prefab.meta
+++ b/Team Rhythm Project 1/Assets/Prefabs/Terrain_3D.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 3ca1853974758dd47a7e298e5caee52c
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Team Rhythm Project 1/Assets/Prefabs/Terrain_Plane.prefab
+++ b/Team Rhythm Project 1/Assets/Prefabs/Terrain_Plane.prefab
@@ -1,6 +1,6 @@
 %YAML 1.1
 %TAG !u! tag:unity3d.com,2011:
---- !u!1 &6227478506255462448
+--- !u!1 &6910363379885240256
 GameObject:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -8,24 +8,25 @@ GameObject:
   m_PrefabAsset: {fileID: 0}
   serializedVersion: 6
   m_Component:
-  - component: {fileID: 1727948863532124052}
-  - component: {fileID: 3284091602950715227}
-  - component: {fileID: 8881239349115591481}
-  - component: {fileID: 3430427759890004952}
+  - component: {fileID: 8374437760062349371}
+  - component: {fileID: 105920477504909980}
+  - component: {fileID: 4554439983224456045}
+  - component: {fileID: 370910360694056296}
+  - component: {fileID: 7928573316039667499}
   m_Layer: 0
-  m_Name: Plane
-  m_TagString: Untagged
+  m_Name: Terrain
+  m_TagString: Terrain
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
---- !u!4 &1727948863532124052
+--- !u!4 &8374437760062349371
 Transform:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 6227478506255462448}
+  m_GameObject: {fileID: 6910363379885240256}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
@@ -33,21 +34,21 @@ Transform:
   m_Father: {fileID: 0}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!33 &3284091602950715227
+--- !u!33 &105920477504909980
 MeshFilter:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 6227478506255462448}
+  m_GameObject: {fileID: 6910363379885240256}
   m_Mesh: {fileID: 10209, guid: 0000000000000000e000000000000000, type: 0}
---- !u!23 &8881239349115591481
+--- !u!23 &4554439983224456045
 MeshRenderer:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 6227478506255462448}
+  m_GameObject: {fileID: 6910363379885240256}
   m_Enabled: 1
   m_CastShadows: 1
   m_ReceiveShadows: 1
@@ -58,7 +59,7 @@ MeshRenderer:
   m_RenderingLayerMask: 1
   m_RendererPriority: 0
   m_Materials:
-  - {fileID: 2100000, guid: 39a33aa0f8a39794595b7a207e62cad2, type: 2}
+  - {fileID: 2100000, guid: cfdd7e38ce44b93448c3f2079a5f88ce, type: 2}
   m_StaticBatchInfo:
     firstSubMesh: 0
     subMeshCount: 0
@@ -78,13 +79,13 @@ MeshRenderer:
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
---- !u!64 &3430427759890004952
+--- !u!64 &370910360694056296
 MeshCollider:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 6227478506255462448}
+  m_GameObject: {fileID: 6910363379885240256}
   m_Material: {fileID: 0}
   m_IsTrigger: 0
   m_Enabled: 1
@@ -92,3 +93,16 @@ MeshCollider:
   m_Convex: 0
   m_CookingOptions: 14
   m_Mesh: {fileID: 10209, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!114 &7928573316039667499
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6910363379885240256}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: ca896d818b73c3943a4e383b49550ae5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  terrainMovementSpeed: 0

--- a/Team Rhythm Project 1/Assets/Prefabs/Terrain_Plane.prefab.meta
+++ b/Team Rhythm Project 1/Assets/Prefabs/Terrain_Plane.prefab.meta
@@ -1,8 +1,7 @@
 fileFormatVersion: 2
-guid: 734e9af7e2023a04e9ce88f5a1ae86ae
-NativeFormatImporter:
+guid: e5fff2acc2320cf4dbf3c0c7075639f7
+PrefabImporter:
   externalObjects: {}
-  mainObjectFileID: 2100000
   userData: 
   assetBundleName: 
   assetBundleVariant: 

--- a/Team Rhythm Project 1/Assets/Scenes/MovementPrototyping.unity
+++ b/Team Rhythm Project 1/Assets/Scenes/MovementPrototyping.unity
@@ -112,6 +112,55 @@ NavMeshSettings:
     debug:
       m_Flags: 0
   m_NavMeshData: {fileID: 0}
+--- !u!1 &160922234
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 160922236}
+  - component: {fileID: 160922235}
+  m_Layer: 0
+  m_Name: TerrainSpawner
+  m_TagString: TerrainSpawner
+  m_Icon: {fileID: 3936346786652291628, guid: 0000000000000000d000000000000000, type: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &160922235
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 160922234}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 42c9fa6518a195444a0d6c7c0fa2388c, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  terrainPrefab: {fileID: 2391261972711336665, guid: 3ca1853974758dd47a7e298e5caee52c,
+    type: 3}
+  terrainSpeed: 15
+  terrainLife: 20
+  waitToStart: 2
+  waitForNextTerrain: 2
+--- !u!4 &160922236
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 160922234}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 50}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!4 &180057755 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: 488160, guid: d9809c5e8418bb047bf2c8ba1d1a2cec,
@@ -634,12 +683,12 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 971090049}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 32, y: 0, z: -15}
+  m_LocalPosition: {x: 0, y: 2, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children:
   - {fileID: 1621880035}
   m_Father: {fileID: 0}
-  m_RootOrder: 1
+  m_RootOrder: 2
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &1292478809
 GameObject:
@@ -653,6 +702,7 @@ GameObject:
   - component: {fileID: 1292478813}
   - component: {fileID: 1292478812}
   - component: {fileID: 1292478811}
+  - component: {fileID: 1292478814}
   m_Layer: 5
   m_Name: Canvas
   m_TagString: Untagged
@@ -669,7 +719,7 @@ RectTransform:
   m_GameObject: {fileID: 1292478809}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 1}
-  m_LocalScale: {x: 0.01, y: 0.01, z: 0.01}
+  m_LocalScale: {x: -0.01, y: 0.01, z: 0.01}
   m_Children:
   - {fileID: 1733959073}
   - {fileID: 469842421}
@@ -678,7 +728,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 0, y: 0}
-  m_AnchoredPosition: {x: 0, y: 0}
+  m_AnchoredPosition: {x: -1.434, y: 0.209}
   m_SizeDelta: {x: 100, y: 125}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &1292478811
@@ -741,6 +791,19 @@ Canvas:
   m_SortingLayerID: 0
   m_SortingOrder: 0
   m_TargetDisplay: 0
+--- !u!114 &1292478814
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1292478809}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0d48ca4b5cdaf1d4796adaaba857ae97, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  lookAtTarget: {fileID: 971090053}
 --- !u!1 &1348461701
 GameObject:
   m_ObjectHideFlags: 0
@@ -1100,77 +1163,3 @@ Transform:
   m_Father: {fileID: 1621880035}
   m_RootOrder: 5
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!1001 &8975055562514748244
-PrefabInstance:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    m_TransformParent: {fileID: 0}
-    m_Modifications:
-    - target: {fileID: 1571380515213885794, guid: e266e1088edb6f54d9de0a9cac56ac8c,
-        type: 3}
-      propertyPath: m_Name
-      value: Plane
-      objectReference: {fileID: 0}
-    - target: {fileID: 1571380515213885794, guid: e266e1088edb6f54d9de0a9cac56ac8c,
-        type: 3}
-      propertyPath: m_IsActive
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6693408756828989871, guid: e266e1088edb6f54d9de0a9cac56ac8c,
-        type: 3}
-      propertyPath: m_LocalPosition.x
-      value: 128
-      objectReference: {fileID: 0}
-    - target: {fileID: 6693408756828989871, guid: e266e1088edb6f54d9de0a9cac56ac8c,
-        type: 3}
-      propertyPath: m_LocalPosition.y
-      value: 7.389703
-      objectReference: {fileID: 0}
-    - target: {fileID: 6693408756828989871, guid: e266e1088edb6f54d9de0a9cac56ac8c,
-        type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 1931
-      objectReference: {fileID: 0}
-    - target: {fileID: 6693408756828989871, guid: e266e1088edb6f54d9de0a9cac56ac8c,
-        type: 3}
-      propertyPath: m_LocalRotation.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6693408756828989871, guid: e266e1088edb6f54d9de0a9cac56ac8c,
-        type: 3}
-      propertyPath: m_LocalRotation.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6693408756828989871, guid: e266e1088edb6f54d9de0a9cac56ac8c,
-        type: 3}
-      propertyPath: m_LocalRotation.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6693408756828989871, guid: e266e1088edb6f54d9de0a9cac56ac8c,
-        type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 6693408756828989871, guid: e266e1088edb6f54d9de0a9cac56ac8c,
-        type: 3}
-      propertyPath: m_RootOrder
-      value: 2
-      objectReference: {fileID: 0}
-    - target: {fileID: 6693408756828989871, guid: e266e1088edb6f54d9de0a9cac56ac8c,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6693408756828989871, guid: e266e1088edb6f54d9de0a9cac56ac8c,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6693408756828989871, guid: e266e1088edb6f54d9de0a9cac56ac8c,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    m_RemovedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: e266e1088edb6f54d9de0a9cac56ac8c, type: 3}

--- a/Team Rhythm Project 1/Assets/Scripts/Cyber/LookAtCamera.cs
+++ b/Team Rhythm Project 1/Assets/Scripts/Cyber/LookAtCamera.cs
@@ -1,0 +1,22 @@
+﻿using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public class LookAtCamera : MonoBehaviour
+{
+    // What to look at.
+    public Transform lookAtTarget;
+    
+    // Start is called before the first frame update
+    void Start()
+    {
+        
+    }
+
+    // Update is called once per frame
+    void Update()
+    {
+        // Point this at the camera.
+        this.transform.LookAt(lookAtTarget);
+    }
+}

--- a/Team Rhythm Project 1/Assets/Scripts/Cyber/LookAtCamera.cs.meta
+++ b/Team Rhythm Project 1/Assets/Scripts/Cyber/LookAtCamera.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 0d48ca4b5cdaf1d4796adaaba857ae97
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Team Rhythm Project 1/Assets/Scripts/Cyber/TerrainManager.cs
+++ b/Team Rhythm Project 1/Assets/Scripts/Cyber/TerrainManager.cs
@@ -1,0 +1,41 @@
+﻿using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public class TerrainManager : MonoBehaviour
+{
+
+    // Terrain prefab to be instantiated.
+    public GameObject terrainPrefab;
+
+    // How fast the terrain moves towards the player.
+    public float terrainSpeed;
+
+    // Life length in seconds of the terrain.
+    public float terrainLife;
+
+    // Timing values for instantiation.
+    public float waitToStart;
+    public float waitForNextTerrain;
+
+
+    // Start is called before the first frame update
+    void Start()
+    {
+        // TimedTerrainPlacement will be called after a delay, and then repeat after a different delay.
+        InvokeRepeating("TimedTerrainPlacement", waitToStart, waitForNextTerrain);
+    }
+
+    // Update is called once per frame
+    void Update()
+    {
+        
+    }
+
+    // Instantiate the terrain prefabs when called.
+     public void TimedTerrainPlacement()
+    {
+        Instantiate(terrainPrefab, this.gameObject.transform.position, this.gameObject.transform.rotation);
+    } 
+
+}

--- a/Team Rhythm Project 1/Assets/Scripts/Cyber/TerrainManager.cs.meta
+++ b/Team Rhythm Project 1/Assets/Scripts/Cyber/TerrainManager.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 42c9fa6518a195444a0d6c7c0fa2388c
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Team Rhythm Project 1/Assets/Scripts/Cyber/TerrainMovementBehaviour.cs
+++ b/Team Rhythm Project 1/Assets/Scripts/Cyber/TerrainMovementBehaviour.cs
@@ -1,0 +1,48 @@
+﻿using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public class TerrainMovementBehaviour : MonoBehaviour
+{
+
+    // Movement speed of this terrain instance.
+    public float terrainMovementSpeed;
+
+    // Terrain life length of this instance.
+    public float thisTerrainLife;
+
+    // Stores a reference to the terrain manager.
+    private GameObject theTerrainManager;
+    
+    // Called when terrain instantiates.
+    void Awake()
+    {
+        // Find the terrain spawner with tag.
+        theTerrainManager = GameObject.FindGameObjectWithTag("TerrainSpawner");
+
+        // Access the terrain manager script on the spawner and set the speed.
+        terrainMovementSpeed = theTerrainManager.gameObject.GetComponent<TerrainManager>().terrainSpeed;
+
+        // Access the terrain manager script and set the life length.
+        thisTerrainLife = theTerrainManager.gameObject.GetComponent<TerrainManager>().terrainLife;
+
+        // Start coroutine determining life of each instance
+        StartCoroutine(LifeOfTerrainInstance());
+
+    }
+
+    // Update is called once per frame
+    void Update()
+    {
+        // Move this instance of terrain.
+        transform.Translate(Vector3.back * Time.deltaTime * terrainMovementSpeed);
+    }
+
+    IEnumerator LifeOfTerrainInstance()
+    {
+        // Wait for the life length of terrain then destroy it.
+        yield return new WaitForSeconds(thisTerrainLife);
+        Destroy(this.gameObject);
+    }
+
+}

--- a/Team Rhythm Project 1/Assets/Scripts/Cyber/TerrainMovementBehaviour.cs.meta
+++ b/Team Rhythm Project 1/Assets/Scripts/Cyber/TerrainMovementBehaviour.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: ca896d818b73c3943a4e383b49550ae5
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Team Rhythm Project 1/ProjectSettings/TagManager.asset
+++ b/Team Rhythm Project 1/ProjectSettings/TagManager.asset
@@ -5,6 +5,8 @@ TagManager:
   serializedVersion: 2
   tags:
   - ResetZone
+  - TerrainSpawner
+  - Terrain
   layers:
   - Default
   - TransparentFX


### PR DESCRIPTION
- setup terrain movement prototype scene
- terrain manager script controls global values for terrain movement speed, life length and instantiates terrain prefabs from the terrain spawner object
 - terrain movement behaviour controls each instanced terrain prefabs movement and destroys at the end of their life
- added a couple of mats
- added a couple of prefabs
- updated some project settings (tags)